### PR TITLE
Add generative commit sculpture

### DIFF
--- a/.github/workflows/generate-sculpture.yml
+++ b/.github/workflows/generate-sculpture.yml
@@ -1,0 +1,30 @@
+name: Generate Commit Sculpture
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install requests trimesh
+      - name: Generate model
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          python scripts/generate_commit_sculpture.py --owner ${{ github.repository_owner }} --repo ${{ github.event.repository.name }} --token $GH_TOKEN --output models/commit_sculpture.glb
+      - name: Commit model
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add models/commit_sculpture.glb
+          git commit -m "Update commit sculpture" || echo "No changes"
+          git push

--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ He has been developing [**#DATAsculpting**](https://open.substack.com/pub/mlearn
 
 ---
 
+## Generative Commit Sculpture
+
+This repository includes an experimental script that turns commit history into a
+3D model. The latest build can be viewed in the repository’s [index page](./index.html).
+Run `scripts/generate_commit_sculpture.py` to create `models/commit_sculpture.glb`.
+Integrate it with GitHub Actions to keep the sculpture updated.
+
+---
+
 ## Connect
 
 - [Twitter](https://twitter.com/Gross_sculptor)  

--- a/index.html
+++ b/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Generative Commit Sculpture</title>
+  <script type="module" src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js"></script>
+  <style>
+    body { font-family: sans-serif; margin: 2rem; }
+    model-viewer { width: 100%; height: 500px; }
+  </style>
+</head>
+<body>
+  <h1>Commit Activity Sculpture</h1>
+  <p>The model below is generated from the commit history of this repository.</p>
+  <model-viewer src="models/commit_sculpture.glb" auto-rotate camera-controls></model-viewer>
+</body>
+</html>

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,29 @@
+# Generative Commit Sculpture
+
+This directory contains `generate_commit_sculpture.py`, a small tool that
+converts commit history into a 3D model. It queries the GitHub API for recent
+commits, groups them by day, and builds a simple glTF bar chart where each bar
+is one day of activity.
+
+## Requirements
+- Python 3.10+
+- `requests`
+- `trimesh` (for creating geometry and exporting glTF)
+
+Install the dependencies with:
+
+```bash
+pip install requests trimesh
+```
+
+## Usage
+
+```bash
+python generate_commit_sculpture.py --owner OWNER --repo REPO --token TOKEN
+```
+
+The script saves a file called `commit_sculpture.glb` inside `models/` by
+default. You can view this file in the browser using `<model-viewer>` or any
+standard glTF viewer.
+
+Integrate it into a GitHub Action to regenerate the model on each push.

--- a/scripts/generate_commit_sculpture.py
+++ b/scripts/generate_commit_sculpture.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Generate a glTF sculpture from GitHub commit history.
+
+This script fetches commit timestamps from a repository and builds a
+very simple bar chart-like 3D model where each day becomes a cube. The
+height of each cube corresponds to the number of commits on that day.
+
+Requirements:
+  - requests
+  - trimesh (for simple geometry + glTF export)
+
+Example usage:
+  python generate_commit_sculpture.py --owner USER --repo REPO \
+    --token YOURTOKEN --days 30 --output models/commit_sculpture.glb
+"""
+
+import argparse
+import datetime
+from collections import defaultdict
+import requests
+import trimesh
+
+
+def fetch_commits(owner: str, repo: str, token: str | None, days: int):
+    """Return a list of commits from the last ``days`` days."""
+    since = (datetime.datetime.utcnow() - datetime.timedelta(days=days))
+    url = f"https://api.github.com/repos/{owner}/{repo}/commits"
+    headers = {"Authorization": f"token {token}"} if token else {}
+    params = {"since": since.isoformat() + "Z", "per_page": 100, "page": 1}
+    commits: list[dict] = []
+    while True:
+        resp = requests.get(url, headers=headers, params=params, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+        if not data:
+            break
+        commits.extend(data)
+        params["page"] += 1
+    return commits
+
+
+def commits_by_day(commits: list[dict]):
+    counts: defaultdict[str, int] = defaultdict(int)
+    for c in commits:
+        date = c["commit"]["committer"]["date"][:10]
+        counts[date] += 1
+    return counts
+
+
+def build_scene(counts: dict[str, int]):
+    meshes = []
+    days = sorted(counts.keys())
+    for i, day in enumerate(days):
+        height = max(1, counts[day])
+        box = trimesh.creation.box(extents=[1.0, height, 1.0])
+        box.apply_translation([i * 1.2, height / 2, 0])
+        meshes.append(box)
+    scene = trimesh.Scene(meshes)
+    return scene
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate commit sculpture")
+    parser.add_argument("--owner", required=True, help="repository owner")
+    parser.add_argument("--repo", required=True, help="repository name")
+    parser.add_argument("--token", help="GitHub token")
+    parser.add_argument("--days", type=int, default=30, help="number of days to scan")
+    parser.add_argument("--output", default="models/commit_sculpture.glb")
+    args = parser.parse_args()
+
+    commits = fetch_commits(args.owner, args.repo, args.token, args.days)
+    counts = commits_by_day(commits)
+    scene = build_scene(counts)
+    scene.export(args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Python script to build a GLB model from repo commits
- document usage in `scripts/README.md`
- host the model with `<model-viewer>` via new `index.html`
- integrate a GitHub Action for automatic updates
- describe the feature in the README

## Testing
- `python3 -m py_compile scripts/generate_commit_sculpture.py`