### PR TITLE
Fix workflow recursion loop

### DIFF
--- a/.github/workflows/generate-sculpture.yml
+++ b/.github/workflows/generate-sculpture.yml
@@ -26,5 +26,5 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add models/commit_sculpture.glb
-          git commit -m "Update commit sculpture" || echo "No changes"
+          git commit -m "Update commit sculpture [skip ci]" || echo "No changes"
           git push


### PR DESCRIPTION
## Summary
- prevent `generate-sculpture` workflow from triggering itself by skipping CI on auto-commits

## Testing
- `python -m py_compile scripts/generate_commit_sculpture.py`
