### PR TITLE
Add permissions for commit sculpture workflow

### DIFF
--- a/.github/workflows/generate-sculpture.yml
+++ b/.github/workflows/generate-sculpture.yml
@@ -1,4 +1,7 @@
 name: Generate Commit Sculpture
+permissions:
+  contents: write
+  pull-requests: write
 
 on:
   push:


### PR DESCRIPTION
## Summary
- allow workflow to write to the repo and pull requests

## Testing
- `git log -1 --stat`