### PR TITLE
Fix indentation for jobs in workflow

### DIFF
--- a/.github/workflows/generate-sculpture.yml
+++ b/.github/workflows/generate-sculpture.yml
@@ -8,14 +8,14 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
-  jobs:
-    build:
-      runs-on: ubuntu-latest
-      steps:
-        # Workflow pushes changes back to the repo.
-        # The push step requires `contents: write` permission.
-        # If the default GITHUB_TOKEN lacks this, supply a PAT via
-        # `GH_PAGES_WRITE_TOKEN` and rotate it periodically.
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Workflow pushes changes back to the repo.
+      # The push step requires `contents: write` permission.
+      # If the default GITHUB_TOKEN lacks this, supply a PAT via
+      # `GH_PAGES_WRITE_TOKEN` and rotate it periodically.
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0


### PR DESCRIPTION
## Summary
- correct indentation of `jobs` in `.github/workflows/generate-sculpture.yml`

## Testing
- `git status --short`