### PR TITLE
Fix push failure in workflow

### DIFF
--- a/.github/workflows/generate-sculpture.yml
+++ b/.github/workflows/generate-sculpture.yml
@@ -40,4 +40,5 @@ jobs:
           git config user.email github-actions@github.com
           git add models/commit_sculpture.glb
           git commit -m "Update commit sculpture [skip ci]" || echo "No changes"
+          git pull --rebase
           git push


### PR DESCRIPTION
## Summary
- add a `git pull --rebase` step in the GitHub Actions workflow

## Testing
- `pre-commit` *(fails: command not found)*