### PR TITLE
Add ignore pattern for generated models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+models/commit_sculpture_gen*.glb


### PR DESCRIPTION
## Summary
- prevent accidental commits of generated 3D models by ignoring `models/commit_sculpture_gen*.glb`

## Testing
- `pytest -q` *(fails: command not found)*