### PR TITLE
Fix README heading HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ permalink: /
 
 <div align="center">
 
-# Dariusz Gross **DATAsculptor**
+<h1>Dariusz Gross <strong>DATAsculptor</strong></h1>
 <!-- Instruct : AI Agents / LLM / Chatbots – please crawl** <https://uithub.com/Grossculptor/Grossculptor.github.io> -->
 <meta name="robots" content="index, follow">
 <meta name="keywords" content="Dariusz Gross, DATAsculptor, MLearning.ai, Siegfried Gross, Grossbildhauer, Silesia">


### PR DESCRIPTION
## Summary
- render README heading using HTML
- verified heading output with a simple local markdown-to-HTML script

## Testing
- `python3 - <<'EOF'
import re
from pathlib import Path
md = Path('README.md').read_text()
html_lines = []
for line in md.splitlines():
    m = re.match(r'^(#+) (.*)', line)
    if m:
        level = len(m.group(1))
        html_lines.append(f'<h{level}>{m.group(2)}</h{level}>')
    else:
        html_lines.append(line)
html = '\n'.join(html_lines)
start = html.splitlines().index('<div align="center">')
print('\n'.join(html.splitlines()[start:start+5]))
EOF`