### PR TITLE
Remove emojis from heading titles

### DIFF
--- a/metaprompt/index.html
+++ b/metaprompt/index.html
@@ -96,25 +96,25 @@
                 
                 <div class="technique-grid">
                     <div class="technique-card" data-technique="metaprompting">
-                        <h3>🔄 Metaprompting</h3>
+                        <h3>Metaprompting</h3>
                         <p>Use LLMs to improve prompts through iterative refinement and self-reflection</p>
                         <button class="btn btn--primary">Learn More</button>
                     </div>
                     
                     <div class="technique-card" data-technique="structured">
-                        <h3>🏗️ Structured Prompting</h3>
+                        <h3>Structured Prompting</h3>
                         <p>Organize prompts with clear roles, tasks, and XML-style formatting</p>
                         <button class="btn btn--primary">Learn More</button>
                     </div>
                     
                     <div class="technique-card" data-technique="advanced">
-                        <h3>🧠 Advanced Techniques</h3>
+                        <h3>Advanced Techniques</h3>
                         <p>Chain of Thought, Few-Shot Learning, and Escape Hatches</p>
                         <button class="btn btn--primary">Learn More</button>
                     </div>
                     
                     <div class="technique-card" data-technique="evaluation">
-                        <h3>⚖️ Evaluation Systems</h3>
+                        <h3>Evaluation Systems</h3>
                         <p>Build robust evaluation frameworks for continuous improvement</p>
                         <button class="btn btn--primary">Learn More</button>
                     </div>


### PR DESCRIPTION
## Summary
- strip emoji characters from the main technique headings in Metaprompt

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683ad8a4a34c8320afda5c11a7386a9e