### PR TITLE
Update playground prompt behaviour

### DIFF
--- a/metaprompt/app.js
+++ b/metaprompt/app.js
@@ -156,6 +156,56 @@ function setupPlayground() {
     const modelSelect = document.getElementById('model-select');
     const analysisOutput = document.getElementById('analysis-output');
 
+    const defaultPrompts = {
+        basic: {
+            claude: "Explain the concept of machine learning to a 10-year-old.",
+            gpt4: "Explain the concept of machine learning to a 10-year-old.",
+            gemini: "Explain the concept of machine learning to a 10-year-old.",
+            llama: "Explain the concept of machine learning to a 10-year-old."
+        },
+        cot: {
+            claude: "Solve this problem step by step: What is 10 + 5?",
+            gpt4: "Solve this problem step by step: What is 10 + 5?",
+            gemini: "Solve this problem step by step: What is 10 + 5?",
+            llama: "Solve this problem step by step: What is 10 + 5?"
+        },
+        'few-shot': {
+            claude: "Classify the following item using the provided examples.",
+            gpt4: "Classify the following item using the provided examples.",
+            gemini: "Classify the following item using the provided examples.",
+            llama: "Classify the following item using the provided examples."
+        },
+        structured: {
+            claude: "<role>Teacher</role>\n<task>Explain a basic concept.</task>",
+            gpt4: "<role>Teacher</role>\n<task>Explain a basic concept.</task>",
+            gemini: "<role>Teacher</role>\n<task>Explain a basic concept.</task>",
+            llama: "<role>Teacher</role>\n<task>Explain a basic concept.</task>"
+        }
+    };
+
+    if (promptInput) {
+        promptInput.readOnly = true;
+    }
+
+    function updatePrompt() {
+        if (!promptInput) return;
+        const tech = techniqueSelect.value;
+        const model = modelSelect.value;
+        const prompt = (defaultPrompts[tech] && defaultPrompts[tech][model]) ||
+            (defaultPrompts.basic && defaultPrompts.basic[model]) ||
+            "Explain the concept of machine learning to a 10-year-old.";
+        promptInput.value = prompt;
+    }
+
+    if (techniqueSelect) {
+        techniqueSelect.addEventListener('change', updatePrompt);
+    }
+    if (modelSelect) {
+        modelSelect.addEventListener('change', updatePrompt);
+    }
+
+    updatePrompt();
+
     if (generateBtn) {
         generateBtn.addEventListener('click', generateResponse);
     }

--- a/metaprompt/index.html
+++ b/metaprompt/index.html
@@ -507,7 +507,7 @@ If the request is outside your capabilities, respond with:
                     <div class="playground-editor">
                         <div class="editor-section">
                             <h4>Your Prompt</h4>
-                            <textarea id="prompt-input" class="form-control playground-textarea" placeholder="Enter your prompt here...">Explain the concept of machine learning to a 10-year-old.</textarea>
+                            <textarea id="prompt-input" class="form-control playground-textarea" placeholder="Enter your prompt here..." readonly>Explain the concept of machine learning to a 10-year-old.</textarea>
                         </div>
 
                         <div class="editor-section">


### PR DESCRIPTION
## Summary
- make the playground prompt textarea readonly
- add default prompts for model & technique selections
- auto-update prompt when selections change

## Testing
- `node --check metaprompt/app.js`


------
https://chatgpt.com/codex/tasks/task_e_683af0826af483209780b7971dd6177b