### PR TITLE
Fix Real-World Application links

### DIFF
--- a/metaprompt/index.html
+++ b/metaprompt/index.html
@@ -409,7 +409,7 @@ If the request is outside your capabilities, respond with:
                             <p><strong>Application:</strong> Powers customer support for Perplexity, Replit, and Bolt</p>
                             <p><strong>Technique:</strong> Structured Prompting with Role Definition</p>
                             <p><strong>Implementation:</strong> Uses detailed 6-page prompts with clear role definitions and step-by-step workflows</p>
-                            <p><strong>Real-World system prompts:</strong> <a href="Parahelp/">Parahelp prompts</a></p>
+                            <p><strong>Real-World system prompts:</strong> <a href="https://github.com/Grossculptor/Grossculptor.github.io/tree/main/metaprompt/Parahelp">Parahelp prompts</a></p>
                             <div class="case-results">
                                 <span class="result-tag">High Accuracy</span>
                                 <span class="result-tag">Consistent Responses</span>
@@ -424,7 +424,7 @@ If the request is outside your capabilities, respond with:
                             <p><strong>Application:</strong> AI-powered IDE that turns plain-English requests into full-stack apps, complete with deployment pipelines.</p>
                             <p><strong>Technique:</strong> Multi-file system-prompt architecture (<code>prompt.txt</code> + <code>tool.json</code>) that defines the agent’s role, available tools, and guard-rails.</p>
                             <p><strong>Implementation:</strong> The agent walks through a checkpointed plan—scaffolding code, running tests, asking clarifying questions, then shipping to the cloud—entirely driven by its layered system prompts.</p>
-                            <p><strong>Real-World system prompts:</strong> <a href="replit/">Replit prompts</a></p>
+                            <p><strong>Real-World system prompts:</strong> <a href="https://github.com/Grossculptor/Grossculptor.github.io/tree/main/metaprompt/replit">Replit prompts</a></p>
                             <div class="case-results">
                                 <span class="result-tag">Rapid Prototyping</span>
                                 <span class="result-tag">Autonomous Agent</span>
@@ -439,7 +439,7 @@ If the request is outside your capabilities, respond with:
                             <p><strong>Application:</strong> In-editor assistant that reviews, edits, and writes code from natural-language instructions, aware of the entire code-base.</p>
                             <p><strong>Technique:</strong> User-configurable “Rules for AI” system prompt and optional <em>YOLO</em> mode let developers pin persistent guidelines (e.g., “write tests first, then code”) to every interaction.</p>
                             <p><strong>Implementation:</strong> The assistant analyses existing files, breaks changes into testable steps, and iterates until tests pass—following the custom system prompt across sessions.</p>
-                            <p><strong>Real-World system prompts:</strong> <a href="cursor/">Cursor prompts</a></p>
+                            <p><strong>Real-World system prompts:</strong> <a href="https://github.com/Grossculptor/Grossculptor.github.io/tree/main/metaprompt/cursor">Cursor prompts</a></p>
                             <div class="case-results">
                                 <span class="result-tag">Codebase-Aware</span>
                                 <span class="result-tag">Test-Driven</span>


### PR DESCRIPTION
## Summary
- fix hyperlinks for Parahelp, Replit and Cursor examples to point to the GitHub prompt folders

## Testing
- `python -m py_compile scripts/commit_randomizer.py scripts/generate_commit_sculpture.py`

------
https://chatgpt.com/codex/tasks/task_e_683b10fa05c08320a6c1e8cb377b27bb