### PR TITLE
Add overview links in metaprompt readmes

### DIFF
--- a/metaprompt/Parahelp/readme.md
+++ b/metaprompt/Parahelp/readme.md
@@ -1,1 +1,1 @@
-
+[Master Prompt Engineering in 2025](https://grossculptor.github.io/metaprompt/#overview) — Discover cutting-edge techniques, best practices, and real-world applications from leading AI companies: 6 Core Techniques, 3 Real-World Cases, 4 Model Personalities.

--- a/metaprompt/cursor/readme.md
+++ b/metaprompt/cursor/readme.md
@@ -1,1 +1,1 @@
-
+[Master Prompt Engineering in 2025](https://grossculptor.github.io/metaprompt/#overview) — Discover cutting-edge techniques, best practices, and real-world applications from leading AI companies: 6 Core Techniques, 3 Real-World Cases, 4 Model Personalities.

--- a/metaprompt/readme.md
+++ b/metaprompt/readme.md
@@ -1,1 +1,1 @@
-
+[Master Prompt Engineering in 2025](https://grossculptor.github.io/metaprompt/#overview) — Discover cutting-edge techniques, best practices, and real-world applications from leading AI companies: 6 Core Techniques, 3 Real-World Cases, 4 Model Personalities.

--- a/metaprompt/replit/readme.md
+++ b/metaprompt/replit/readme.md
@@ -1,1 +1,1 @@
-
+[Master Prompt Engineering in 2025](https://grossculptor.github.io/metaprompt/#overview) — Discover cutting-edge techniques, best practices, and real-world applications from leading AI companies: 6 Core Techniques, 3 Real-World Cases, 4 Model Personalities.


### PR DESCRIPTION
## Summary
- add an overview link with a short description to all README files in the metaprompt section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683b1773763083208a384641003444ed